### PR TITLE
upgrade to django 4

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Data is harvested from a variety of "data sources." Datasources are then associa
 
 # Installation and Development
 
-You will need to install "[pip](https://pip.pypa.io/en/stable/installation/)" (the python package management system) and "[virtualenv](https://virtualenv.pypa.io/en/latest/installation.html)" (a python virtual environment manager) to your system. You can install virtualenv like: `sudo -H pip3 install virtualenv`
+This project uses python 3.10. You will need to install "[pip](https://pip.pypa.io/en/stable/installation/)" (the python package management system) and "[virtualenv](https://virtualenv.pypa.io/en/latest/installation.html)" (a python virtual environment manager) to your system. You can install virtualenv like: `sudo -H pip3 install virtualenv`
 
 ## Installing Packages
 

--- a/bankgreen/settings.py
+++ b/bankgreen/settings.py
@@ -12,8 +12,14 @@ https://docs.djangoproject.com/en/3.2/ref/settings/
 import os
 from pathlib import Path
 
+import django
+from django.utils.encoding import force_str
+
 from dotenv import load_dotenv
 
+
+# this hack is necessary because force_text is removed from django4, but graphene < 3 requires it
+django.utils.encoding.force_text = force_str
 
 """
 The .env file should be on the same dir as this file, that is loaded through load_dotenv().

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ airtable==0.4.8
 black==22.3.0
 isort==5.10.1
 celery==4.0.0
-django==3.2.12
+django==4.0.5
 django-braces==1.15.0
 django-cryptography==1.0
 django-celery-beat==2.0.0
@@ -13,7 +13,7 @@ django-model-utils==4.2.0
 djangorestframework==3.13.1
 django-cors-headers==3.12.0
 networkx==2.5.1
-pandas==1.1.5
+pandas==1.4.2
 pycountry==22.1.10
 python-dotenv==0.19.2
 qwikidata==0.4.0
@@ -24,6 +24,7 @@ django-countries==7.2.1
 gunicorn==20.1.0
 django-admin-list-filter-dropdown==1.0.3
 python-Levenshtein==0.12.2
+graphene==2.1.9
 graphene-django==2.15.0
 django-filter==21.1
 np==1.0.2


### PR DESCRIPTION
django_graphene specifies a version of graphene that isn't fully compatible with django 4. As a result, I had to do that little hack in settings.py

Another note: On my machine, the resolve countries bit of `ingest_airtable` is now broken. I had to revert to
`defaults["countries"] = [pycountries.get(country.lower()) for country in ar]` to get it to work, but think that this may have to do with how different versions of pandas parse and store data that's received from the airtable api. This is more of a note than to say that we need to do anything with it. Hopefully in the near future we can delete that command entirely.

Resolves #48 

