### PR TITLE
Update Github Workflow to use python 3.10

### DIFF
--- a/.github/workflows/django-ci.yml
+++ b/.github/workflows/django-ci.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.8]
+        python-version: ["3.10"]
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
Noted that we the README recommends moving to Python 3.10 from issue #52, switching Github Actions to the same version.

I did this in Github web editor and they wanted me to make the EOF spacing change..