### PR TITLE
chore: upgrade `graphene` and `django-graphene` to v3

### DIFF
--- a/brand/schema.py
+++ b/brand/schema.py
@@ -205,6 +205,7 @@ class CommentaryType(DjangoObjectType):
             "show_on_sustainable_banks_page",
         ]
         interfaces = (relay.Node,)
+        convert_choices_to_enum = False
 
 
 class FeatureTypeType(DjangoObjectType):
@@ -226,6 +227,7 @@ class BrandFeatureType(DjangoObjectType):
     class Meta:
         model = BrandFeature
         fields = "__all__"
+        convert_choices_to_enum = False
 
 
 class Query(graphene.ObjectType):

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,8 +23,8 @@ django-countries==7.2.1
 gunicorn==20.1.0
 django-admin-list-filter-dropdown==1.0.3
 python-Levenshtein==0.12.2
-graphene==2.1.9
-graphene-django==2.15.0
+graphene==3.2.1
+graphene-django==3.0.0
 django-filter==21.1
 jsonfield==3.1.0
 django-json-widget==1.1.1


### PR DESCRIPTION
this also closes PE-468.

Upgrade `graphene` and `django-graphene` to v3 since `django-graphene` v2 most likely won't get any new stable release.

Only 2 migration tweaks are needed

- `django-graphene` v3 automatically converts fields with `choices` attribute to the GraphQL type `enum`. `convert_choices_to_enum = False` is to prevent this.

- `django-graphene` v3 no longer converts IN filters to accept list. In `django-graphene` v2 we can just set `class RegionFilter(BaseInFilter, CharFilter)` and then do `{"regions": ["a", "b"]}`, but in `django-graphene` v3 we have to use `TypedFilter` and set `input_type=graphene.List(graphene.String)` manually. Otherwise we can only do `{"regions": "a,b"}`.

Tested with all the queries in `GraphQL-README.md`. Everything works.