### PR TITLE
feat: make datasources queryable

### DIFF
--- a/GraphQL-README.md
+++ b/GraphQL-README.md
@@ -52,6 +52,15 @@ query BrandsQuery(
           }
           details
         }
+        datasources {
+          edges {
+            node {
+              name
+              sourceLink
+              subclass
+            }
+          }
+        }
       }
     }
   }
@@ -100,6 +109,15 @@ query BrandByTagQuery($tag: String!) {
         name
       }
       details
+    }
+    datasources {
+      edges {
+        node {
+          name
+          sourceLink
+          subclass
+        }
+      }
     }
   }
 }
@@ -171,6 +189,15 @@ query BrandsQuery(
             name
           }
           details
+        }
+        datasources {
+          edges {
+            node {
+              name
+              sourceLink
+              subclass
+            }
+          }
         }
       }
     }

--- a/brand/schema.py
+++ b/brand/schema.py
@@ -22,8 +22,17 @@ from cities_light.models import Region, SubRegion
 
 
 class DatasourceType(DjangoObjectType):
+    subclass = graphene.String()
+
+    def resolve_subclass(obj, info):
+        try:
+            return type(obj.subclass()).__name__
+        except NotImplementedError:
+            return None
+
     class Meta:
         model = Datasource
+        fields = ("name", "source_link")
         interfaces = (relay.Node,)
 
 
@@ -128,6 +137,7 @@ class BrandNodeType(DjangoObjectType):
             "aliases",
             "regions",
             "subregions",
+            "datasources",
         ]
         interfaces = (relay.Node,)
         filterset_class = BrandFilter
@@ -152,6 +162,7 @@ class BrandType(DjangoObjectType):
             "bank_features",
             "regions",
             "subregions",
+            "datasources",
         )
 
 


### PR DESCRIPTION
closes PE-507

a couple of caveats,

1. should we change `subclass` graphql field to something else more informative to user?
2. for a generic `Datasource` without a subclass it just returns `subclass: Datasource` which might be confusing.