### PR TITLE
feat: unregister datasource from admin

### DIFF
--- a/datasource/admin.py
+++ b/datasource/admin.py
@@ -117,7 +117,6 @@ class HasSuggestedAssociationsFilter(admin.SimpleListFilter):
         return queryset
 
 
-@admin.register(Datasource)
 class DatasourceAdmin(admin.ModelAdmin):
     list_display = ["name", "source_id"]
     search_fields = ["name", "source_id"]


### PR DESCRIPTION
- unregisters datasource base class from the admin panel
- This at least makes it impossible for end users to accidentally create generic datasource records for now
- datasource should really be an abstract class, but making it so causes quite a lot of many-to-many table-name-collisions