### PR TITLE
Fix issue with checking for self recursive brand before save

### DIFF
--- a/brand/models/commentary.py
+++ b/brand/models/commentary.py
@@ -74,7 +74,7 @@ class Commentary(models.Model):
     def compute_inherited_rating(self, inheritance_set=None, throw_error=False):
 
         inheritance_set = set() if inheritance_set is None else inheritance_set
-        brand_in_inheritance_set = self.brand in inheritance_set
+        brand_in_inheritance_set = self.brand.tag in inheritance_set
 
         if throw_error and brand_in_inheritance_set:
             raise ValidationError(
@@ -85,7 +85,7 @@ class Commentary(models.Model):
         elif self.rating == RatingChoice.INHERIT and not self.inherit_brand_rating:
             return RatingChoice.UNKNOWN
         elif self.rating == RatingChoice.INHERIT and self.inherit_brand_rating:
-            inheritance_set.add(self.brand)
+            inheritance_set.add(self.brand.tag)
             return self.inherit_brand_rating.commentary.compute_inherited_rating(
                 inheritance_set, throw_error=throw_error
             )
@@ -162,7 +162,7 @@ class Commentary(models.Model):
 
     def clean(self):
         # Ensure no cycles when saving
-        _ = self.compute_inherited_rating(throw_error=True)
+        self.compute_inherited_rating(throw_error=True)
 
     def save(self, *args, **kwargs):
         if self.inherit_brand_rating:

--- a/brand/tests/test.py
+++ b/brand/tests/test.py
@@ -146,8 +146,7 @@ class CommentaryTestCase(TestCase):
             rssd="another rssd",
         )
 
-        brand5 = Brand.objects.create(
-            pk=500,
+        brand5 = Brand(
             tag="another_brand_5",
             name="Another Brand 5",
             aliases="another brand, anotherb",
@@ -172,7 +171,7 @@ class CommentaryTestCase(TestCase):
 
         # brands 4 and 5 point at eachother for their ratings
         self.commentary4 = Commentary.objects.create(brand=brand4, rating=RatingChoice.OK)
-        self.commentary5 = Commentary.objects.create(
+        self.commentary5 = Commentary(
             brand=brand5, rating=RatingChoice.INHERIT, inherit_brand_rating=brand4
         )
         self.commentary4.inherit_brand_rating = brand5

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,7 +29,7 @@ jsonfield==3.1.0
 django-json-widget==1.1.1
 np==1.0.2
 Markdown==3.3.7
-markdown-link-attr-modifier==0.2.0
+markdown-link-attr-modifier>=0.2.0,<0.3
 django-cities-light==3.9.2
 symspellpy==6.7.7
 django-autocomplete-light==3.9.4


### PR DESCRIPTION
Following #111, creating a new `Brand` with `Commentary` with the web form would result in

```py
TypeError: "Model instances without primary key value are unhashable"
```

This is due to the check for self recursive brand. Before `.save`, the `Brand` `pk`  has not been created yet and thus is not yet hashable and cannot be used in a set. The fix is to use `tag` instead, which is also non-null and unique. Also modified the test to check without saving.