### PR TITLE
chore: update graphene-django to v3.0.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ gunicorn==20.1.0
 django-admin-list-filter-dropdown==1.0.3
 python-Levenshtein==0.12.2
 graphene==3.2.1
-graphene-django==3.0.0
+graphene-django>=3.0.1,<3.1
 django-filter==21.1
 jsonfield==3.1.0
 django-json-widget==1.1.1


### PR DESCRIPTION
graphene-django 3.0.1 upgrades graphiql from 1.4.1, which contains a potential security vulnerability, to 2.4.1.

graphiql v2 also has much nicer UI.

![Screenshot 2023-04-30 at 01-48-52 Screenshot](https://user-images.githubusercontent.com/6521018/235317241-158455d6-1f39-4780-9d43-8daf7585d6d4.png)
