### PR TITLE
feat: enable graphql/ with trailing slash

### DIFF
--- a/bankgreen/urls.py
+++ b/bankgreen/urls.py
@@ -43,7 +43,7 @@ urlpatterns = [
         views.SubRegionAutocomplete.as_view(),
         name="subregion-autocomplete",
     ),
-    path("calendar", views.calendar_redirect, name="calendar"),
+    path("calendar/", views.calendar_redirect, name="calendar"),
     path("update/<str:tag>/", views.CreateUpdateView.as_view(), name="update"),
     path("update_success/", views.update_success, name="update_success"),
 ] + static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)

--- a/bankgreen/urls.py
+++ b/bankgreen/urls.py
@@ -16,7 +16,7 @@ Including another URLconf
 from django.conf import settings
 from django.conf.urls.static import static
 from django.contrib import admin
-from django.urls import path, reverse_lazy
+from django.urls import path, re_path, reverse_lazy
 from django.views.decorators.cache import cache_control
 from django.views.decorators.csrf import csrf_exempt
 from django.views.generic.base import RedirectView
@@ -31,8 +31,8 @@ from brand import views
 urlpatterns = [
     path("admin/", admin.site.urls),
     path("", RedirectView.as_view(url=reverse_lazy("admin:index"))),
-    path(
-        "graphql",
+    re_path(
+        "^graphql/?$",
         cache_control(max_age=settings.CACHE_MAX_AGE)(
             csrf_exempt(GraphQLView.as_view(graphiql=True, schema=schema))
         ),


### PR DESCRIPTION
Enable `graphql/` in addition to `graphql`.

Apart from making it more flexible for the consumer of the API, there's another reason for this related to DX.

Some browsers, including Firefox and Chrome, have this long standing bug where if you successfully visit both the slashed and non-slashed version of a URL before, the next time you visit the non-slashed version the browser will automatically insert the trailing slash. Thus if I'm a dev and work locally on another project that enables `graphql/` and visit `localhost:8000/graphql/` successfully, then switch to this project, when I go to `localhost:8000/graphql` the browser will automatically make it `localhost:8000/graphql/` which is non-existent. Resolving this requires deleting the `localhost:8000/graphql/` entry in browser history.

Rewriting it to `path("graphql/", ...` would be fine for a pure GET route since django would automatically redirect the non-slashed route to the slashed one if exists (see [`APPEND_SLASH`](https://docs.djangoproject.com/en/4.2/ref/settings/#append-slash)), but since our GraphQL route is also POST the request payload is not included during the redirection and so we have to do [`re_path`](https://docs.djangoproject.com/en/4.2/ref/urls/#re-path)`("^graphql/?$", ...`. I have tested this successfully with both GET and POST, slashed and non-slashed.

Also did this for the `calendar` route for consistency. This is already a redirect route so just `path("calendar/", ...` is fine.

Sorry for the essay.