### PR TITLE
Validation of brand tags

### DIFF
--- a/brand/models/brand.py
+++ b/brand/models/brand.py
@@ -318,3 +318,9 @@ class Brand(TimeStampedModel):
         }
 
         return spelling_dict
+
+    def save(self, *args, **kwargs):
+        if not re.match("^[A-Za-z0-9_-]*$", str(self.tag)):
+            raise Exception("Tag can contain only alpha-numeric characters, underscores and dashes")
+
+        return super().save(*args, **kwargs)

--- a/brand/models/brand.py
+++ b/brand/models/brand.py
@@ -4,6 +4,7 @@ from typing import List, Tuple
 from django.db import models
 from django.db.models.query import QuerySet
 from django.template.defaultfilters import truncatechars
+from django.core.exceptions import ValidationError
 
 from cities_light.models import Region, SubRegion
 from django_countries.fields import CountryField
@@ -14,6 +15,13 @@ from datasource.constants import lev_distance, model_names
 
 
 # from Levenshtein import distance as lev
+
+def validate_tag(value):
+    """ This is the function that is used to validate the TAG """
+    if re.match("^[A-Za-z0-9_-]*$", str(value)):
+        return value
+    else:
+        raise ValidationError("Tag can contain only alpha-numeric characters, underscores and dashes")
 
 
 class Brand(TimeStampedModel):
@@ -68,6 +76,7 @@ class Brand(TimeStampedModel):
         editable=True,
         unique=True,
         help_text="the tag we use or this brand record at Bank.Green. ",
+        validators=[validate_tag]
     )
     tag_locked = models.BooleanField(default=True)
 
@@ -320,7 +329,5 @@ class Brand(TimeStampedModel):
         return spelling_dict
 
     def save(self, *args, **kwargs):
-        if not re.match("^[A-Za-z0-9_-]*$", str(self.tag)):
-            raise Exception("Tag can contain only alpha-numeric characters, underscores and dashes")
-
+        self.full_clean()
         return super().save(*args, **kwargs)

--- a/brand/models/brand.py
+++ b/brand/models/brand.py
@@ -16,12 +16,15 @@ from datasource.constants import lev_distance, model_names
 
 # from Levenshtein import distance as lev
 
+
 def validate_tag(value):
-    """ This is the function that is used to validate the TAG """
+    """This is the function that is used to validate the TAG"""
     if re.match("^[A-Za-z0-9_-]*$", str(value)):
         return value
     else:
-        raise ValidationError("Tag can contain only alpha-numeric characters, underscores and dashes")
+        raise ValidationError(
+            "Tag can contain only alpha-numeric characters, underscores and dashes"
+        )
 
 
 class Brand(TimeStampedModel):
@@ -76,7 +79,7 @@ class Brand(TimeStampedModel):
         editable=True,
         unique=True,
         help_text="the tag we use or this brand record at Bank.Green. ",
-        validators=[validate_tag]
+        validators=[validate_tag],
     )
     tag_locked = models.BooleanField(default=True)
 

--- a/brand/tests/test.py
+++ b/brand/tests/test.py
@@ -205,24 +205,23 @@ class BrandTagTestCase(TestCase):
             name="Test Brand 1",
             tag="Tag_Brand-1"
         )
+        # this should not raise any errors
         brand1.save()
 
-        # test for Invalid Tag
-
-    # test for an Invalid Tag
+    # test for an Invalid Tags
     def test_brand_invalid_tag(self):
+        # test case with not allowed characters
+        brand1 = Brand(
+            name="Test Brand 1",
+            tag="TagBrand%$1")
 
-        with self.assertRaises(Exception):
-            brand1 = Brand(
-                name="Test Brand 1",
-                tag="Tag_Brand-1$"
-            )
+        with self.assertRaises(ValidationError):
             brand1.save()
 
         # test case with the spaces
-        with self.assertRaises(Exception):
-            brand1 = Brand(
-                name="Test Brand 1",
-                tag="Tag Brand 1"
-            )
+        brand1 = Brand(
+            name="Test Brand 1",
+            tag="Tag Brand 1")
+
+        with self.assertRaises(ValidationError):
             brand1.save()

--- a/brand/tests/test.py
+++ b/brand/tests/test.py
@@ -198,30 +198,22 @@ class CommentaryTestCase(TestCase):
 
 
 class BrandTagTestCase(TestCase):
-
     # test for a Valid Tag
     def test_brand_valid_tag(self):
-        brand1 = Brand(
-            name="Test Brand 1",
-            tag="Tag_Brand-1"
-        )
+        brand1 = Brand(name="Test Brand 1", tag="Tag_Brand-1")
         # this should not raise any errors
         brand1.save()
 
     # test for an Invalid Tags
     def test_brand_invalid_tag(self):
         # test case with not allowed characters
-        brand1 = Brand(
-            name="Test Brand 1",
-            tag="TagBrand%$1")
+        brand1 = Brand(name="Test Brand 1", tag="TagBrand%$1")
 
         with self.assertRaises(ValidationError):
             brand1.save()
 
         # test case with the spaces
-        brand1 = Brand(
-            name="Test Brand 1",
-            tag="Tag Brand 1")
+        brand1 = Brand(name="Test Brand 1", tag="Tag Brand 1")
 
         with self.assertRaises(ValidationError):
             brand1.save()

--- a/brand/tests/test.py
+++ b/brand/tests/test.py
@@ -195,3 +195,34 @@ class CommentaryTestCase(TestCase):
         self.assertEqual(
             self.commentary5.compute_inherited_rating(throw_error=False), RatingChoice.UNKNOWN
         )
+
+
+class BrandTagTestCase(TestCase):
+
+    # test for a Valid Tag
+    def test_brand_valid_tag(self):
+        brand1 = Brand(
+            name="Test Brand 1",
+            tag="Tag_Brand-1"
+        )
+        brand1.save()
+
+        # test for Invalid Tag
+
+    # test for an Invalid Tag
+    def test_brand_invalid_tag(self):
+
+        with self.assertRaises(Exception):
+            brand1 = Brand(
+                name="Test Brand 1",
+                tag="Tag_Brand-1$"
+            )
+            brand1.save()
+
+        # test case with the spaces
+        with self.assertRaises(Exception):
+            brand1 = Brand(
+                name="Test Brand 1",
+                tag="Tag Brand 1"
+            )
+            brand1.save()

--- a/brand/tests/utils.py
+++ b/brand/tests/utils.py
@@ -7,7 +7,7 @@ def create_test_brands():
         tag="test_brand_1",
         name="Test Brand 1",
         aliases="test brand, testb",
-        website="www.testbrand.com",
+        website="http://www.testbrand.com",
         permid="test permid",
         viafid="test viafid",
         lei="test lei",


### PR DESCRIPTION
Currently, when adding a new Brand, the Tag can be saved with any characters in it. It should allow only alpha-numeric characters, dashed and underscores.

This change checks for not-allowed characters in the Tag field on Save. If it finds them, the Save of the form does not happen, and the error message is displayed near the Tag field.
Also, the integration tests for this functionality are completed.



