### PR TITLE
feat: reenable from-the-website field until it's back in prismic

### DIFF
--- a/brand/admin.py
+++ b/brand/admin.py
@@ -34,14 +34,7 @@ class CommentaryInline(admin.StackedInline):
     model = Commentary
     autocomplete_fields = ["inherit_brand_rating"]
 
-    readonly_fields = (
-        "rating_inherited",
-        "from_the_website",
-        "subtitle",
-        "header",
-        "summary",
-        "details",
-    )
+    readonly_fields = ("rating_inherited", "subtitle", "header", "summary", "details")
     fieldsets = (
         (
             "Display Configuration",


### PR DESCRIPTION
This is necessary because the from-the-website field was deprecated but apparently not migrated. This field needs to be enabled to be edited.

I've made a followup ticket ([GROOT-131](https://linear.app/bankgreen/issue/GROOT-131/add-fromthewebsite-to-sfi-page)) for adding the field to prismic and only using data.bank.green as a fallback