### PR TITLE
GROOT-138: show revert button on history display

### DIFF
--- a/brand/templates/reversion/revision_form.html
+++ b/brand/templates/reversion/revision_form.html
@@ -1,0 +1,8 @@
+{% extends "reversion/revision_form.html" %}
+{% load i18n admin_urls %}
+
+{% block submit_buttons_bottom %}{% with is_popup=1 %}
+{% block submit-row %}
+  <input type="submit" value="{% translate 'Revert to this version' %}" class="default" name="_save">
+{% endblock %}
+{% endwith %}{% endblock %}


### PR DESCRIPTION
When viewing a brand's history, the "save" button now displays as "revert to this version" (sample URL: http://127.0.0.1:8000/admin/brand/brand/747/history/19/). This makes it clear that you are reverting, not saving new changes, by clicking on the button. 

Buttons remain the same on the brand change page (sample URL: http://127.0.0.1:8000/admin/brand/brand/747/change/).

![Screenshot 2024-03-24 at 9 38 18 PM](https://github.com/bank-green/bankgreen-django/assets/7718254/a39dea60-8341-4319-a51c-5f089f1a86be)
