### PR TITLE
introduce dbg graphql caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,13 @@ location /graphql {
 Then restart Nginx and Gunicorn:
 `sudo systemctl restart nginx && sudo systemctl restart gunicorn`
 
+## Generating GraphQL schema (Introspection Schema)
+Dumps GraphQL schema data to `./gql_schema.json` ([More info here](https://docs.graphene-python.org/projects/django/en/latest/introspection/))
+
+```bash
+python manage.py graphql_schema
+```
+
 # Deploying
 Deployment uses the `Justfile`, which you can also copy and paste into your terminal if you prefer. Otherwise, this will require
 1. Installing the `just` ([packages here](https://github.com/casey/just?tab=readme-ov-file#packages))

--- a/bankgreen/settings.py
+++ b/bankgreen/settings.py
@@ -193,3 +193,10 @@ REST_FRAMEWORK = {
     "DEFAULT_AUTHENTICATION_CLASSES": ["api.authentication.SingleTokenAuthentication"],
     "DEFAULT_PERMISSION_CLASSES": ["rest_framework.permissions.IsAuthenticated"],
 }
+
+CACHES = {
+    "default": {
+        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+        "LOCATION": "bgd_memcache",
+    }
+}

--- a/bankgreen/settings.py
+++ b/bankgreen/settings.py
@@ -196,7 +196,8 @@ REST_FRAMEWORK = {
 
 CACHES = {
     "default": {
-        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
-        "LOCATION": "bgd_memcache",
+        "BACKEND": "django.core.cache.backends.db.DatabaseCache",
+        "LOCATION": "bgd_cache_table",
+        "TIMEOUT": 60 * 20,
     }
 }

--- a/bankgreen/settings.py
+++ b/bankgreen/settings.py
@@ -174,8 +174,12 @@ CORS_ALLOWED_ORIGIN_REGEXES = (
 
 CACHE_MAX_AGE = os.environ.get("CACHE_MAX_AGE")
 
-# lets us pull all banks at once without pagination
-GRAPHENE = {"RELAY_CONNECTION_MAX_LIMIT": 10000}
+GRAPHENE = {
+    # lets us pull all banks at once without pagination
+    "RELAY_CONNECTION_MAX_LIMIT": 10000,
+    "SCHEMA": "brand.schema.schema",
+    "SCHEMA_OUTPUT": "gql_schema.json",
+}
 
 CITIES_LIGHT_TRANSLATION_LANGUAGES = [""]
 CITIES_LIGHT_INCLUDE_CITY_TYPES = [""]

--- a/brand/schema.py
+++ b/brand/schema.py
@@ -477,6 +477,8 @@ class Query(graphene.ObjectType):
     brands = DjangoFilterConnectionField(Brand)
 
     def resolve_brands(self, info, **kwargs):
+        cache_timeout_in_minutes = 20
+
         sorted_args = json.dumps(kwargs, sort_keys=True)
         cache_key = f"brand_query_cache{hashlib.md5(sorted_args.encode('utf-8')).hexdigest()}"
 
@@ -492,7 +494,7 @@ class Query(graphene.ObjectType):
         else:
             result = queryset
 
-        cache.set(cache_key, result, timeout=60 * 10)
+        cache.set(cache_key, result, timeout=60 * cache_timeout_in_minutes)
         return result
 
     features = DjangoListField(Feature)

--- a/brand/schema.py
+++ b/brand/schema.py
@@ -1,8 +1,10 @@
 import ast
+import hashlib
 import json
 import logging
 import re
 
+from django.core.cache import cache
 from django.db.models import Case, Count, Q, When
 
 import graphene
@@ -473,6 +475,25 @@ class Query(graphene.ObjectType):
             raise GraphQLError(str(e))
 
     brands = DjangoFilterConnectionField(Brand)
+
+    def resolve_brands(self, info, **kwargs):
+        sorted_args = json.dumps(kwargs, sort_keys=True)
+        cache_key = f"brand_query_cache{hashlib.md5(sorted_args.encode('utf-8')).hexdigest()}"
+
+        cached_result = cache.get(cache_key)
+        if cached_result:
+            return cached_result
+
+        queryset = BrandModel.objects.all()
+        filterset = BrandFilter(data=kwargs, queryset=queryset)
+
+        if filterset.is_valid():
+            result = filterset.qs
+        else:
+            result = queryset
+
+        cache.set(cache_key, result, timeout=60 * 10)
+        return result
 
     features = DjangoListField(Feature)
 


### PR DESCRIPTION
Adds a cache for the brand query call that `speed rater` makes.
I've tested it locally.

also it's unrelated but I snuck in the  graphql introspection schema generation functionality