### PR TITLE
Matthew/groot 312 dbg refreshes harvest data periodically for sfis

### DIFF
--- a/datasource/management/commands/refresh_sfi_harvest_data.py
+++ b/datasource/management/commands/refresh_sfi_harvest_data.py
@@ -1,0 +1,12 @@
+from django.core.management.base import BaseCommand
+from brand.models import Commentary
+from brand.utils.harvest_data import update_commentary_feature_data
+
+
+class Command(BaseCommand):
+    help = "Fetches the harvest data of SFI Brands then updates the Brand's Commentary"
+
+    def handle(self, *args, **options):
+        sfi_commentaries = Commentary.objects.filter(show_on_sustainable_banks_page=True)
+        for commentary in sfi_commentaries:
+            update_commentary_feature_data(commentary, overwrite=True)

--- a/datasource/management/commands/refresh_sfi_harvest_data.py
+++ b/datasource/management/commands/refresh_sfi_harvest_data.py
@@ -1,12 +1,23 @@
+import logging
 from django.core.management.base import BaseCommand
 from brand.models import Commentary
 from brand.utils.harvest_data import update_commentary_feature_data
+
+"""
+    To be used with cron job, please see GROOT-312 ticket for more context
+"""
 
 
 class Command(BaseCommand):
     help = "Fetches the harvest data of SFI Brands then updates the Brand's Commentary"
 
     def handle(self, *args, **options):
+        print("Fetching Commentaries...")
         sfi_commentaries = Commentary.objects.filter(show_on_sustainable_banks_page=True)
+        print("Updating commentaries...")
         for commentary in sfi_commentaries:
-            update_commentary_feature_data(commentary, overwrite=True)
+            try:
+                update_commentary_feature_data(commentary, overwrite=True)
+            except Exception as e:
+                print(f"{commentary.brand.tag} failed...")
+                print(e)

--- a/datasource/management/commands/refresh_sfi_harvest_data.py
+++ b/datasource/management/commands/refresh_sfi_harvest_data.py
@@ -1,7 +1,10 @@
 import logging
+
 from django.core.management.base import BaseCommand
+
 from brand.models import Commentary
 from brand.utils.harvest_data import update_commentary_feature_data
+
 
 """
     To be used with cron job, please see GROOT-312 ticket for more context

--- a/scripts/groot-376.py
+++ b/scripts/groot-376.py
@@ -1,7 +1,8 @@
 from brand.models import *
 
-full_headlines = Commentary.objects.all().exclude(headline__isnull=True).exclude(headline='')
-full_subtitles = Commentary.objects.all().exclude(subtitle__isnull=True).exclude(subtitle='')
+
+full_headlines = Commentary.objects.all().exclude(headline__isnull=True).exclude(headline="")
+full_subtitles = Commentary.objects.all().exclude(subtitle__isnull=True).exclude(subtitle="")
 
 tags = {x.brand.tag for x in full_headlines}.union({x.brand.tag for x in full_subtitles})
 
@@ -9,6 +10,6 @@ for tag in tags:
     print(tag)
     print(f"HEADLINE: {Brand.objects.get(tag=tag).commentary.headline}")
     print(f"SUBTITLE: {Brand.objects.get(tag=tag).commentary.subtitle}")
-    print('----')
+    print("----")
 
-full_headlines.update(headline='')
+full_headlines.update(headline="")


### PR DESCRIPTION
(Please check out the [linear ticket](https://linear.app/bankgreen/issue/GROOT-312/dbg-refreshes-harvest-data-periodically-for-sfis) to see my proposed shell script to be used with cron job.)

There was already a utility function that refreshes the data, so I used that.
The only question I have is that the utility fn defaults the brand's `country` to an empty string ([here](https://github.com/bank-green/bankgreen-django/blob/main/brand/utils/harvest_data.py#L51)), 
but in other script we default the country to `"UK"`. which is correct?