### PR TITLE
Matthew/groot 379/fix graphql features filter query

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ To setup the database, you must run migrations, add sample data by installing th
 `python manage.py migrate`   
 `python manage.py loaddata fixtures/initial/initial.json`   
 `python manage.py cities_light`   
+`python manage.py createcachetable`
 
 Then create a superuser:   
 `python manage.py createsuperuser`

--- a/brand/schema.py
+++ b/brand/schema.py
@@ -126,12 +126,11 @@ class BrandFilter(FilterSet):
 
     def filter_features(self, queryset, name, value):
         # return all brands that have "Yes" or "Maybe" for all given features
-        query = Q()
         for v in value:
-            query &= Q(
-                bank_features__feature__name__in=value, bank_features__offered__in=["Yes", "Maybe"]
+            queryset = queryset.filter(
+                bank_features__feature__name=v, bank_features__offered__in=["Yes", "Maybe"]
             )
-        return queryset.filter(query)
+        return queryset
 
     def filter_rating(self, queryset, name, value):
         # ratings matching the query exactly

--- a/brand/schema.py
+++ b/brand/schema.py
@@ -126,13 +126,12 @@ class BrandFilter(FilterSet):
 
     def filter_features(self, queryset, name, value):
         # return all brands that have "Yes" or "Maybe" for all given features
-        return (
-            queryset.filter(
+        query = Q()
+        for v in value:
+            query &= Q(
                 bank_features__feature__name__in=value, bank_features__offered__in=["Yes", "Maybe"]
             )
-            .annotate(num_feats=Count("bank_features"))
-            .filter(num_feats=len(value))
-        )
+        return queryset.filter(query)
 
     def filter_rating(self, queryset, name, value):
         # ratings matching the query exactly


### PR DESCRIPTION
### Background:
querying the graphql brand query endpoint with multiple `feature` filters returns empty.
example would be `"features": ["checking", "saving"],` returning nothing when there are instances that have both.

### Issue
the problem was the underlying filter logic.
it checks if any brand matches the queried features then checks the exact number of features listed in the brand are equal to the queried features.
the problem is that if a brand has more features than what's being queried it get filtered out.

### Fix
build a query by queried features without regard to the number of feature on the brand