### PR TITLE
groot-414 fix query bug

### DIFF
--- a/brand/management/commands/refresh_brand_locations.py
+++ b/brand/management/commands/refresh_brand_locations.py
@@ -18,7 +18,7 @@ class Command(BaseCommand):
         brands_by_country = {}
 
         for country in self.countries:
-            brands_by_country[country] = Brand.objects.filter(countries__in=[country])
+            brands_by_country[country] = Brand.objects.filter(countries__contains=country)
         print(f"Initialized...")
         for country, brands in brands_by_country.items():
             for brand in brands:


### PR DESCRIPTION
### the bug
`countries__in=[country]` was not returning brand with multiple countries, only exact match.
### why?
this is because `countries` does not have a many-to-many relationship with Brand, rather, it's just a varchar (string of text) of the countries. so while `__in` would be the correct query for many-to-many it does not behave the same way on a string.
### solution:
`__contains` is the proper query, it searches the string for matching substring 